### PR TITLE
Niloofar/FEQ-1434/Added platforms to package.json exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
       "require": "./dist/Markets/index.cjs",
       "types": "./dist/Markets/index.d.ts"
     },
+    "./Platforms": {
+      "import": "./dist/Platforms/index.js",
+      "require": "./dist/Platforms/index.cjs",
+      "types": "./dist/Platforms/index.d.ts"
+    },
     "./Social": {
       "import": "./dist/Social/index.js",
       "require": "./dist/Social/index.cjs",


### PR DESCRIPTION
In this PR I fixed this issue: `Module '"@deriv/quill-icons"' has no exported member 'PlatformsDerivAppsDarkIcon'.ts(2305)` 