### PR TITLE
Fixing Notification Display in Slack Channels with PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,6 @@ jobs:
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
-    outputs:
-      RELEASE_VERSION: ${{ steps.extract_version.outputs.RELEASE_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,7 +43,7 @@ jobs:
         run: npx semantic-release
       - name: Extract version
         id: extract_version
-        run: echo "RELEASE_VERSION=${version}" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=RELEASE_VERSION::$(git describe --tags --abbrev=0)"
       - name: Trigger Quill Icons Park release
         if: success()
         env:
@@ -72,9 +70,9 @@ jobs:
         id: create_slack_message
         run: |
           if [ "${{ env.WORKFLOW_CONCLUSION }}" == "success" ]; then
-            echo "MESSAGE=${{ env.RELEASE_TYPE }} Release succeeded for @deriv/quill-icons with version ${{ needs.release.outputs.RELEASE_VERSION }} 🥳" >> $GITHUB_OUTPUT
+            echo "MESSAGE=${{ env.RELEASE_TYPE }} Release succeeded for @deriv/quill-icons with version ${{ steps.extract_version.outputs.RELEASE_VERSION }} 🥳" >> $GITHUB_OUTPUT
           else
-            echo "MESSAGE=${{ env.RELEASE_TYPE }} Release failed for @deriv/quill-icons with version ${{ needs.release.outputs.RELEASE_VERSION }} 🤨" >> $GITHUB_OUTPUT
+            echo "MESSAGE=${{ env.RELEASE_TYPE }} Release failed for @deriv/quill-icons with version ${{ steps.extract_version.outputs.RELEASE_VERSION }} 🤨" >> $GITHUB_OUTPUT
           fi
       - name: Send Slack Notification
         uses: './.github/actions/send_slack_notifications'


### PR DESCRIPTION
Currently, when we send a notification in the Slack channel, it doesn't display the current version accurately. This pull request addresses and fixes this issue, ensuring that the notification reflects the correct version information.