### PR TITLE
Moving quill-icons to @deriv-com on npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@deriv/quill-icons",
+  "name": "@deriv-com/quill-icons",
   "version": "1.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@deriv/quill-icons",
+      "name": "@deriv-com/quill-icons",
       "version": "1.23.4",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@deriv/quill-icons",
+  "name": "@deriv-com/quill-icons",
   "version": "1.23.4",
   "description": "This is the central repository for quill icons, exported from figma design file",
   "files": [


### PR DESCRIPTION
I have created this PR to ensure consistency in our npm packages namespaces.